### PR TITLE
fix graphite adapter, introduce docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  graphite:
+    image: hopsoft/graphite-statsd
+    ports: 
+      - 8090:80
+      - 2003:2003
+      - 2004:2004
+      - 2023:2023
+      - 2024:2024
+      - 8125:8125
+      - 8126:8126
+    container_name: graphite.price
+  grafana:
+    image: grafana/grafana
+    ports:
+      - 7777:3000
+    container_name: grafana
+    links:
+      - app
+      - "graphite:graphite.price"
+  app:
+    container_name: price_monitor
+    build: salt/docker/pm_container/
+    ports:
+      - 9999:3000
+    environment:
+      RAILS_ENV: development
+      SECRET_KEY_BASE: secret_key
+    links:
+      - "graphite:graphite.price"

--- a/rails_app/app/adapters/graphite_adapter.rb
+++ b/rails_app/app/adapters/graphite_adapter.rb
@@ -29,7 +29,7 @@ class GraphiteAdapter
     URI::HTTP.build({
       host: @graphite_host,
       path: '/render',
-      port: 8080,
+      port: Settings.graphite.http_port,
       query: {
         target: metric,
         format: type,

--- a/rails_app/config/settings/development.yml
+++ b/rails_app/config/settings/development.yml
@@ -1,6 +1,7 @@
 graphite:
-    host: 172.17.0.3
+    host: graphite.price
     port: 2003
+    http_port: 80
     metric_prefix: price_monitor_internal
     default_get_metric_time: "-14d"
 

--- a/rails_app/config/settings/production.yml
+++ b/rails_app/config/settings/production.yml
@@ -1,6 +1,7 @@
 graphite:
     host: graphite.price
     port: 2003
+    http_port: 8080
     metric_prefix: price_monitor_internal
     default_get_metric_time: "-14d"
 


### PR DESCRIPTION
Since salt is a bit overkill when dealing with single server instance, docker-compose seems a bit more convincing way to do it.
To run it, just simply type `docker-compose up -d` and you're good to go